### PR TITLE
Remove a box with a reference to a non-existing file from the home page

### DIFF
--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -25,9 +25,6 @@
         [[INCLUDE::/ssi/rapid_release.html]]
       </div>
       <div class="plain-box">
-        [[INCLUDE::/ssi/zt_annotation.md]]
-      </div>
-      <div class="plain-box">
         [[INCLUDE::/ssi/archives.md]]
       </div>
       <div class="plain-box">


### PR DESCRIPTION
Removing a box without content from the home page of the site.

The missing markdown file that the code refers to might have been an advertisement for community annotation for Zymoseptoria tritici.

![image](https://github.com/user-attachments/assets/d08177f0-c9c0-46ec-9011-6690a8611cfe)
