### PR TITLE
Removing wrong item/fungus from the INI file

### DIFF
--- a/conf/SiteDefs.pm
+++ b/conf/SiteDefs.pm
@@ -79,7 +79,6 @@ sub update_conf {
         melampsora_laricipopulina
         microbotryum_violaceum
         mucor_lusitanicus
-        neosartorya_fischeri
         neurospora_crassa
         phaeosphaeria_nodorum
         phanerochaete_chrysosporium


### PR DESCRIPTION
Removing wrong item/fungus from the INI file
* `neosartorya fischeri` became `aspergillus fischeri` and - as such - should be removed.